### PR TITLE
Add CI to run notebooks

### DIFF
--- a/.github/workflows/evaluate_notebooks.yml
+++ b/.github/workflows/evaluate_notebooks.yml
@@ -1,0 +1,32 @@
+name: Evaluate notebooks
+
+# start job only for PRs when a label is added.
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  build:
+    if: contains(github.event.pull_request.labels.*.name, 'evaluate-notebooks')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.ref }}
+    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/cache@v1
+    - uses: julia-actions/julia-buildpkg@v1
+    - name: Evaluate notebooks
+      shell: bash -l {0}
+      run: |
+        julia --project evaluate_notebooks.jl
+    - name: Commit
+      shell: bash -l {0}
+      run: |
+        git config --global user.name "${GITHUB_ACTOR}"
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git add examples/
+        git status
+        git commit -m "Automatically evaluated notebooks from PR ${{ github.event.number }}, branch ${{ github.event.pull_request.head.ref }}."
+        git push origin "${{ github.event.pull_request.head.ref }}"

--- a/.github/workflows/evaluate_notebooks.yml
+++ b/.github/workflows/evaluate_notebooks.yml
@@ -23,6 +23,8 @@ jobs:
         julia --project evaluate_notebooks.jl
     - name: Commit
       shell: bash -l {0}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git config --global user.name "${GITHUB_ACTOR}"
         git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"

--- a/evaluate_notebooks.jl
+++ b/evaluate_notebooks.jl
@@ -1,0 +1,12 @@
+using Literate
+using Glob
+
+cd("examples")
+
+files = glob("*-*.jl")
+
+for f in files
+    if occursin("Logistic", f)
+        Literate.notebook(f; execute = true)
+    end
+end


### PR DESCRIPTION
I am having two issues here, the first can be solved but there is no point if the second cannot.

The first is that the action requires an access token to be allowed to make a commit. 

The second is that running all notebooks takes too long. Splitting them up into one action per notebook isn't possible (at least not straightforwardly and without hard coding the notebook names), and doing only those that have changed may be possible but I don't see a great way of determining that (what to compare to, the second to last commit, the main branch, etc, I don't think there's a choice that will always make sense).

So I would say to put this on hold unless someone has an idea how to deal with the second issue.

The good news is that we should just be able to do it manually with the workflow:
- make changes to the source of a notebook
- commit them, pre-commit will overwrite the notebook with an unevaluated but up to date notebook
- if we want the output to be visible in the notebook, just run manually and commit separately

the precommit only triggers when the source is changed, so it won't interfere in the last step.

It's maybe not ideal, but good enough I guess, especially considering that we'll also have notebooks that have to run on the GPU for which we need to do this anyway.

The precommit will only guarantee that notebooks are up to date with their source, but if any of the code in the package that it depends on changes (which doesn't change the unevaluated notebook but can cause changes in the results), they are not updated. So if we want to be careful, we have to run all notebooks manually as a last commit before merging any PR.

