### PR TITLE
Fix aposteriori

### DIFF
--- a/simulations/NavierStokes_2D/scripts/NeuralClosure+SciML.jl
+++ b/simulations/NavierStokes_2D/scripts/NeuralClosure+SciML.jl
@@ -150,7 +150,7 @@ pred[:, :, :, 1] == example2.u[:, :, :, 1] # Sci-ML also keeps the initial condi
 # * Define the loss (a-posteriori) - old way
 function loss_posteriori(model, p, st, data)
     u, t = data
-    griddims = Zygote.@ignore ((:) for _ in 1:(ndims(u) - 2))
+    griddims = axes(u)[1:(ndims(u) - 2)]
     x = u[griddims..., :, 1]
     y = u[griddims..., :, 2:end] # remember to discard sol at the initial time step
     #dt = params.Δt

--- a/src/equations/NavierStokes_utils.jl
+++ b/src/equations/NavierStokes_utils.jl
@@ -34,29 +34,17 @@ This formulation was the one proved best in Syver's paper i.e. DCF.
 """
 create_right_hand_side_with_closure(setup, psolver, closure, st) = function right_hand_side(
         u, p, t)
-#    u_INS = NN_padded_to_INS(u, setup)
+    u_INS = NN_padded_to_INS(u, setup)
 #    u_nopad = NN_padded_to_NN_nopad(u, setup)
 #    u_for_lux = reshape(u_nopad, size(u_nopad)..., 1)
-#    u = INS.apply_bc_u(u_INS, t, setup)
-#    F = INS.momentum(u, nothing, t, setup)
-#    u_lux = Lux.apply(closure, u_for_lux, p, st)[1]
-#    FC = sum_NN_nopad_and_INS(u_lux, F, setup)
-#    FC = INS.apply_bc_u(F, t, setup; dudt = true)
-#    FP = INS.project(FC, setup; psolver)
-#    FP = INS.apply_bc_u(FP, t, setup; dudt = true)
-#    INS_to_NN(FP)
-    u_INS = eachslice(u; dims = ndims(u))
-    u_INS = (u_INS...,)
     u_INS = INS.apply_bc_u(u_INS, t, setup)
     F = INS.momentum(u_INS, nothing, t, setup)
-    F = INS.apply_bc_u(F, t, setup; dudt = true)
     u_lux = Lux.apply(closure, u[:,:,:,1:1], p, st)[1]
-    F1 = F[1] + u_lux[:,:,1,1]
-    F2 = F[2] + u_lux[:,:,2,1]
-    F12 = (F1,F2)
-    PF = INS.project(F12, setup; psolver)
-    PF = INS.apply_bc_u(PF, t, setup; dudt = true)
-    cat(PF[1], PF[2]; dims = 3)
+    FC = (F[1] + u_lux[:,:,1,1], F[2] + u_lux[:,:,2,1])
+    FC = INS.apply_bc_u(FC, t, setup; dudt = true)
+    FP = INS.project(FC, setup; psolver)
+    FP = INS.apply_bc_u(FP, t, setup; dudt = true)
+    INS_to_NN(FP)
 end
 
 """
@@ -185,14 +173,15 @@ function NN_padded_to_INS(u, setup)
     if ndims(u) == D + 1
         u_INS = eachslice(u, dims = ndims(u))
         (u_INS...,)
-    elseif ndims(u) == D + 2
-        if size(u, ndims(u)) != 1
-            error("Only a single timeslice is supported")
-        end
-        Tuple(
-            u[griddims..., d, 1]
-        for d in 1:size(u, ndims(u) - 1)
-        )
+    # TODO: look at this edge case
+    #elseif ndims(u) == D + 2
+    #    if size(u, ndims(u)) != 1
+    #        error("Only a single timeslice is supported")
+    #    end
+    #    Tuple(
+    #        u[griddims..., d, 1]
+    #    for d in 1:size(u, ndims(u) - 1)
+    #    )
     else
         error("Unsupported or non-matching number of dimensions in IO array")
     end

--- a/src/equations/NavierStokes_utils.jl
+++ b/src/equations/NavierStokes_utils.jl
@@ -34,18 +34,29 @@ This formulation was the one proved best in Syver's paper i.e. DCF.
 """
 create_right_hand_side_with_closure(setup, psolver, closure, st) = function right_hand_side(
         u, p, t)
-    # not sure if we should keep t as a parameter. t is only necessary for the INS functions when having Dirichlet BCs (time dependent)
-    u_INS = NN_padded_to_INS(u, setup)
-    u_nopad = NN_padded_to_NN_nopad(u, setup)
-    u_for_lux = reshape(u_nopad, size(u_nopad)..., 1)
-    u = INS.apply_bc_u(u_INS, t, setup)
-    F = INS.momentum(u, nothing, t, setup)
-    u_lux = Lux.apply(closure, u_for_lux, p, st)[1]
-    FC = sum_NN_nopad_and_INS(u_lux, F, setup)
-    FC = INS.apply_bc_u(F, t, setup; dudt = true)
-    FP = INS.project(FC, setup; psolver)
-    FP = INS.apply_bc_u(FP, t, setup; dudt = true)
-    INS_to_NN(FP)
+#    u_INS = NN_padded_to_INS(u, setup)
+#    u_nopad = NN_padded_to_NN_nopad(u, setup)
+#    u_for_lux = reshape(u_nopad, size(u_nopad)..., 1)
+#    u = INS.apply_bc_u(u_INS, t, setup)
+#    F = INS.momentum(u, nothing, t, setup)
+#    u_lux = Lux.apply(closure, u_for_lux, p, st)[1]
+#    FC = sum_NN_nopad_and_INS(u_lux, F, setup)
+#    FC = INS.apply_bc_u(F, t, setup; dudt = true)
+#    FP = INS.project(FC, setup; psolver)
+#    FP = INS.apply_bc_u(FP, t, setup; dudt = true)
+#    INS_to_NN(FP)
+    u_INS = eachslice(u; dims = ndims(u))
+    u_INS = (u_INS...,)
+    u_INS = INS.apply_bc_u(u_INS, t, setup)
+    F = INS.momentum(u_INS, nothing, t, setup)
+    F = INS.apply_bc_u(F, t, setup; dudt = true)
+    u_lux = Lux.apply(closure, u[:,:,:,1:1], p, st)[1]
+    F1 = F[1] + u_lux[:,:,1,1]
+    F2 = F[2] + u_lux[:,:,2,1]
+    F12 = (F1,F2)
+    PF = INS.project(F12, setup; psolver)
+    PF = INS.apply_bc_u(PF, t, setup; dudt = true)
+    cat(PF[1], PF[2]; dims = 3)
 end
 
 """


### PR DESCRIPTION
This PR fixes the a posteriori fitting by using the function that worked in the Enzyme branch of our fork of INS.

This is just a draft so some of the functions developed by @v1kko have not been included yet.

Notice that this primitive version is not discarding the boundaries of `u` while passing it to Lux.

We can use this branch as a base to fix the a posterior fitting problem.