### PR TITLE
HPC compatibility

### DIFF
--- a/simulations/NavierStokes_2D/scripts/generate_data.jl
+++ b/simulations/NavierStokes_2D/scripts/generate_data.jl
@@ -3,7 +3,6 @@ using JLD2: jldsave
 using Random: Random
 
 T = Float32
-ArrayType = Array
 rng = Random.Xoshiro(123)
 
 # Generate the data using NeuralClosure

--- a/simulations/NavierStokes_2D/scripts/preprocess_posteriori.jl
+++ b/simulations/NavierStokes_2D/scripts/preprocess_posteriori.jl
@@ -2,7 +2,6 @@ using Random: Random
 using IncompressibleNavierStokes: IncompressibleNavierStokes as INS
 
 T = Float32
-ArrayType = Array
 rng = Random.Xoshiro(123)
 
 # Load the data

--- a/simulations/NavierStokes_2D/scripts/preprocess_priori.jl
+++ b/simulations/NavierStokes_2D/scripts/preprocess_priori.jl
@@ -2,7 +2,6 @@ using Random: Random
 using IncompressibleNavierStokes: IncompressibleNavierStokes as INS
 
 T = Float32
-ArrayType = Array
 rng = Random.Xoshiro(123)
 
 # Load the data

--- a/simulations/NavierStokes_2D/scripts/train_posteriori.jl
+++ b/simulations/NavierStokes_2D/scripts/train_posteriori.jl
@@ -47,8 +47,8 @@ loss_posteriori_lux = create_loss_post_lux(dudt_nn2; sciml_solver = Tsit5())
 loss_posteriori_lux(closure, θ, st, train_data_posteriori)
 
 # * Callback function
-callback_validation = create_callback(
-    dudt_nn2, test_io_post[ig], loss_posteriori_lux, st, nunroll = 3 * nunroll,
+callbackstate_val, callback_val = create_callback(
+    dudt_nn2, θ, test_io_post[ig], loss_posteriori_lux, st, nunroll = 3 * nunroll,
     rng = rng, do_plot = true, plot_train = false)
 θ_posteriori = θ
 
@@ -56,7 +56,7 @@ callback_validation = create_callback(
 lux_result, lux_t, lux_mem, _ = @timed train(
     closure, θ_posteriori, st, dataloader_posteriori, loss_posteriori_lux;
     nepochs = 50, ad_type = Optimization.AutoZygote(),
-    alg = OptimizationOptimisers.Adam(0.01), cpu = true, callback = callback_validation)
+    alg = OptimizationOptimisers.Adam(0.01), cpu = true, callback = callback_val)
 
 loss, tstate = lux_result
 # the trained params are:

--- a/simulations/NavierStokes_2D/scripts/train_posteriori.jl
+++ b/simulations/NavierStokes_2D/scripts/train_posteriori.jl
@@ -8,7 +8,6 @@ using OptimizationOptimisers: OptimizationOptimisers
 using Random: Random
 
 T = Float32
-ArrayType = Array
 rng = Random.Xoshiro(123)
 ig = 1 # index of the LES grid to use.
 include("preprocess_posteriori.jl")

--- a/simulations/NavierStokes_2D/scripts/train_priori.jl
+++ b/simulations/NavierStokes_2D/scripts/train_priori.jl
@@ -1,5 +1,5 @@
 using CoupledNODE: cnn, create_loss_priori, mean_squared_error, loss_priori_lux,
-                   create_stateful_callback, create_callback, train
+                   create_callback, train
 using IncompressibleNavierStokes: IncompressibleNavierStokes as INS
 using JLD2: @save
 using Lux: Lux

--- a/simulations/NavierStokes_2D/scripts/train_priori.jl
+++ b/simulations/NavierStokes_2D/scripts/train_priori.jl
@@ -8,7 +8,6 @@ using OptimizationOptimisers: OptimizationOptimisers
 using Random: Random
 
 T = Float32
-ArrayType = Array
 rng = Random.Xoshiro(123)
 ig = 1 # index of the LES grid to use.
 include("preprocess_priori.jl")

--- a/simulations/NavierStokes_2D/scripts/train_priori.jl
+++ b/simulations/NavierStokes_2D/scripts/train_priori.jl
@@ -40,7 +40,7 @@ loss_priori_lux(closure, θ, st, train_data_priori)
 callbackstate, callback = create_stateful_callback(θ)
 # alternative callback
 callback_validation = create_callback(
-    closure, test_io_post[ig], loss_priori, st, batch_size = 500,
+    closure, test_io_post[ig], loss_priori, st, batch_size = 100,
     rng = rng, do_plot = true, plot_train = false)
 
 # * Training (via Lux)

--- a/simulations/NavierStokes_2D/scripts/train_priori.jl
+++ b/simulations/NavierStokes_2D/scripts/train_priori.jl
@@ -36,17 +36,15 @@ loss_priori(closure, θ, st, train_data_priori) # check that the loss is working
 # * loss in the Lux format
 loss_priori_lux(closure, θ, st, train_data_priori)
 
-# Define the callback
-callbackstate, callback = create_stateful_callback(θ)
-# alternative callback
-callback_validation = create_callback(
-    closure, test_io_post[ig], loss_priori, st, batch_size = 100,
+# * Define the callback
+callbackstate_val, callback_val = create_callback(
+    closure, θ, test_io_post[ig], loss_priori, st, batch_size = 100,
     rng = rng, do_plot = true, plot_train = false)
 
 # * Training (via Lux)
 loss, tstate = train(closure, θ, st, dataloader_prior, loss_priori_lux;
     nepochs = 50, ad_type = Optimization.AutoZygote(),
-    alg = OptimizationOptimisers.Adam(0.1), cpu = true, callback = callback_validation)
+    alg = OptimizationOptimisers.Adam(0.1), cpu = true, callback = callback_val)
 # the trained parameters at the end of the training are: 
 θ_priori = tstate.parameters
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,5 @@
 using CairoMakie: CairoMakie
+using Random: Random
 using Statistics: mean
 using CoupledNODE.NavierStokes: create_dataloader_posteriori, create_dataloader_prior
 
@@ -10,16 +11,16 @@ Create a callback function for training and validation of a model.
 # Arguments
 - `model`: The model for the rhs.
 - `θ`: parameters of the model (trainable).
-- `val_io_data`: The validation input-output data for validation.
+- `val_io_data`: The validation io_array.
 - `loss_function`: The loss function to be used.
 - `st`: The state of the model.
 - `callbackstate`: a `NamedTuple` that is updated durign the trainign and contains:
     - `θmin`: The parameters at the minimum validation loss.
     - `loss_min`: The minimum validation loss.
-    - `lhist`: A list to store the history of validation losses. Defaults to a new empty list.
+    - `lhist_val`: A list to store the history of validation losses. Defaults to a new empty list.
     - `lhist_train`: A list to store the history of training losses. Defaults to a new empty list.
-- `nunroll`: The number of unroll steps for the validation loss. It does not have to be the same as the loss function!
-- `rng`: The random number generator to be used. Defaults to `rng`.
+- `nunroll`: The number of unroll steps for the validation loss. It does not have to be the same as the loss function! Pertinent for a-posteriori training.
+- `rng`: The random number generator to be used.
 - `plot_train`: A boolean flag to indicate whether to plot the training loss.
 - `do_plot`: A boolean flag to indicate whether to generate the plots. In HPC systems we may want to deactivate it.
 - `plot_every`: The frequency of plotting the loss history. Defaults to 10. The loss is also averaged in this window.
@@ -39,7 +40,7 @@ function create_callback(
         model, θ, val_io_data, loss_function, st;
         callbackstate = (;
             θmin = θ, loss_min = eltype(θ)(Inf), lhist_val = [], lhist_train = []),
-        nunroll = nothing, batch_size = nothing, rng = rng, do_plot = true,
+        nunroll = nothing, batch_size = nothing, rng = Random.Xoshiro(123), do_plot = true,
         plot_train = true, plot_every = 10)
     if nunroll === nothing && batch_size === nothing
         error("Either nunroll or batch_size must be provided")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -41,16 +41,14 @@ function create_callback(
             θmin = θ, loss_min = eltype(θ)(Inf), lhist_val = [], lhist_train = []),
         nunroll = nothing, batch_size = nothing, rng = rng, do_plot = true,
         plot_train = true, plot_every = 10)
-    if nunroll === nothing
-        if batch_size === nothing
-            error("Either nunroll or batch_size must be provided")
-        else
-            @info "Creating a priori callback"
-            dataloader = create_dataloader_prior(val_io_data; batchsize = batch_size, rng)
-        end
-    else
+    if nunroll === nothing && batch_size === nothing
+        error("Either nunroll or batch_size must be provided")
+    elseif nunroll !== nothing
         @info "Creating a posteriori callback"
         dataloader = create_dataloader_posteriori(val_io_data; nunroll = nunroll, rng)
+    else
+        @info "Creating a priori callback"
+        dataloader = create_dataloader_prior(val_io_data; batchsize = batch_size, rng)
     end
     # select a fixed sample for the validation
     y1, y2 = dataloader()

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,49 +2,14 @@ using CairoMakie: CairoMakie
 using Statistics: mean
 using CoupledNODE.NavierStokes: create_dataloader_posteriori, create_dataloader_prior
 
-function create_stateful_callback(
-        θ,
-        err_function = nothing,
-        callbackstate = (; θmin = θ, θmin_e = θ, loss_min = eltype(θ)(Inf),
-            emin = eltype(θ)(Inf), hist = CairoMakie.Point2f[]),
-        displayref = false,
-        display_each_iteration = true,
-        filename = nothing
-)
-    #istart = isempty(callbackstate.hist) ? 0 : Int(callbackstate.hist[end][1])
-    obs = CairoMakie.Observable([CairoMakie.Point2f(0, 0)])
-    fig = CairoMakie.lines(obs; axis = (; title = "Error", xlabel = "step"))
-    displayref && CairoMakie.hlines!([1.0f0]; linestyle = :dash)
-    obs[] = callbackstate.hist
-    display(fig)
-    function callback(θ, loss)
-        if err_function !== nothing
-            e = err_function(θ)
-            #@info "Iteration $i \terror: $e"
-            e < state.emin && (callbackstate = (; callbackstate..., θmin_e = θ, emin = e))
-        end
-        hist = push!(
-            copy(callbackstate.hist), CairoMakie.Point2f(length(callbackstate.hist), loss))
-        obs[] = hist
-        CairoMakie.autolimits!(fig.axis)
-        display_each_iteration && display(fig)
-        isnothing(filename) || save(filename, fig)
-        callbackstate = (; callbackstate..., hist)
-        loss < callbackstate.loss_min &&
-            (callbackstate = (; callbackstate..., θmin = θ, loss_min = loss))
-        callbackstate
-    end
-    (; callbackstate, callback)
-end
-
 """
-    create_callback(model, test_io_data; lhist=[], lhist_train=[], nunroll=10, rng=rng, plot_train=true)
+    create_callback(model, val_io_data; lhist=[], lhist_train=[], nunroll=10, rng=rng, plot_train=true)
 
 Create a callback function for training and validation of a model.
 
 # Arguments
 - `model`: The model for the rhs.
-- `test_io_data`: The test input-output data for validation.
+- `val_io_data`: The validation input-output data for validation.
 - `lhist`: A list to store the history of validation losses. Defaults to a new empty list.
 - `lhist_train`: A list to store the history of training losses. Defaults to a new empty list.
 - `nunroll`: The number of unroll steps for the validation loss. It does not have to be the same as the loss function!
@@ -66,60 +31,62 @@ A callback function that can be used during training to compute and log validati
 - Otherwise, returns `false` to operate as expected from a callback function.
 """
 function create_callback(
-        model, test_io_data, loss_function, st; lhist = [], lhist_train = [],
-        nunroll = nothing, batch_size = nothing, rng = rng, do_plot = true, plot_train = true)
+        model, θ, val_io_data, loss_function, st;
+        callbackstate = (;
+            θmin = θ, loss_min = eltype(θ)(Inf), lhist_val = [], lhist_train = []),
+        nunroll = nothing, batch_size = nothing, rng = rng, do_plot = true,
+        plot_train = true, plot_every = 10)
     if nunroll === nothing
         if batch_size === nothing
             error("Either nunroll or batch_size must be provided")
         else
-            print("Creating a priori callback")
-            dataloader = create_dataloader_prior(test_io_data; batchsize = batch_size, rng)
+            @info "Creating a priori callback"
+            dataloader = create_dataloader_prior(val_io_data; batchsize = batch_size, rng)
         end
     else
-        print("Creating a posteriori callback")
-        dataloader = create_dataloader_posteriori(test_io_data; nunroll = nunroll, rng)
+        @info "Creating a posteriori callback"
+        dataloader = create_dataloader_posteriori(val_io_data; nunroll = nunroll, rng)
     end
     # select a fixed sample for the validation
     y1, y2 = dataloader()
-    no_model_loss = nothing
+    no_model_loss = loss_function(model, θ .* 0, st, (y1, y2))[1]
 
-    function (p, ltrain, pred = nothing; return_lhist = false)
-        if return_lhist
-            return lhist, lhist_train
-        end
-        l_l = length(lhist)
-        if no_model_loss === nothing
-            # reference loss without model
-            no_model_loss = loss_function(model, p .* 0, st, (y1, y2))[1]
-        end
+    function callback(p, l_train)
+        step = length(callbackstate.lhist_val)
         # to compute the validation loss, use the parameters p at this step
-        l = loss_function(model, p, st, (y1, y2))[1]
+        l_val = loss_function(model, p, st, (y1, y2))[1]
 
-        @info "Training Loss[$(l_l)]: $(ltrain)"
-        @info "Validation Loss[$(l_l)]: $(l)"
-        push!(lhist, l)
-        push!(lhist_train, ltrain)
+        @info "Training Loss[$(step)]: $(l_train)"
+        @info "Validation Loss[$(step)]: $(l_val)"
+        push!(callbackstate.lhist_val, l_val)
+        push!(callbackstate.lhist_train, l_train)
+        l_val < callbackstate.loss_min &&
+            (callbackstate = (; callbackstate..., θmin = θ, loss_min = l_val))
         if do_plot
             fig = CairoMakie.Figure()
             ax = CairoMakie.Axis(fig[1, 1], title = "Loss", xlabel = "Iterations",
                 ylabel = "Loss", yscale = CairoMakie.log10)
-            # plot rolling average of loss, every 10 steps
-            if l_l % 10 == 0
-                x = 1:10:length(lhist)
-                y = [mean(lhist[i:min(i + 9, length(lhist))]) for i in 1:10:length(lhist)]
+            # plot rolling average of loss, every plot_every steps
+            if step % plot_every == 0
+                x = 1:plot_every:length(callbackstate.lhist_val)
+                y = [mean(callbackstate.lhist_val[i:min(
+                         i + plot_every - 1, length(callbackstate.lhist_val))])
+                     for i in 1:plot_every:length(callbackstate.lhist_val)]
                 CairoMakie.lines!(ax, x, y, label = "Validation")
                 if plot_train
-                    x = 1:10:length(lhist_train)
-                    y = [mean(lhist[i:min(i + 9, length(lhist_train))])
-                         for i in 1:10:length(lhist_train)]
+                    x = 1:plot_every:length(callbackstate.lhist_train)
+                    y = [mean(callbackstate.lhist_train[i:min(
+                             i + plot_every - 1, length(callbackstate.lhist_train))])
+                         for i in 1:plot_every:length(callbackstate.lhist_train)]
                     CairoMakie.lines!(ax, x, y, label = "Training")
                 end
-                CairoMakie.lines!(ax, [0, length(lhist)], [no_model_loss, no_model_loss],
-                    label = "Val (no closure)")
+                CairoMakie.lines!(ax, [0, length(callbackstate.lhist_val)],
+                    [no_model_loss, no_model_loss], label = "Val (no closure)")
                 CairoMakie.axislegend(ax)
                 display(fig)
             end
         end
-        return false
+        callbackstate
     end
+    (; callbackstate, callback)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,26 +9,31 @@ Create a callback function for training and validation of a model.
 
 # Arguments
 - `model`: The model for the rhs.
+- `θ`: parameters of the model (trainable).
 - `val_io_data`: The validation input-output data for validation.
-- `lhist`: A list to store the history of validation losses. Defaults to a new empty list.
-- `lhist_train`: A list to store the history of training losses. Defaults to a new empty list.
+- `loss_function`: The loss function to be used.
+- `st`: The state of the model.
+- `callbackstate`: a `NamedTuple` that is updated durign the trainign and contains:
+    - `θmin`: The parameters at the minimum validation loss.
+    - `loss_min`: The minimum validation loss.
+    - `lhist`: A list to store the history of validation losses. Defaults to a new empty list.
+    - `lhist_train`: A list to store the history of training losses. Defaults to a new empty list.
 - `nunroll`: The number of unroll steps for the validation loss. It does not have to be the same as the loss function!
 - `rng`: The random number generator to be used. Defaults to `rng`.
 - `plot_train`: A boolean flag to indicate whether to plot the training loss.
+- `do_plot`: A boolean flag to indicate whether to generate the plots. In HPC systems we may want to deactivate it.
+- `plot_every`: The frequency of plotting the loss history. Defaults to 10. The loss is also averaged in this window.
 
 # Returns
-A callback function that can be used during training to compute and log validation and training losses, and optionally plot the loss history.
+A `NamedTuple` with the `callbackstate`` and the callback function.
+The callback function is used during training to compute and log validation and training losses, and optionally plot the loss history.
 
-# Callback Function Arguments
+# Callback function arguments
 - `p`: The parameters of the model at the current training step.
-- `ltrain`: The training loss at the current training step.
-- `pred`: Optional. The predictions of the model at the current training step. Defaults to `nothing`.
-- `do_plot`: Optional. A boolean flag to indicate whether to plot the loss history. Defaults to `true`.
-- `return_lhist`: Optional. A boolean flag to indicate whether to return the loss history. Defaults to `false`.
+- `l_train`: The training loss at the current training step.
 
-# Callback Function Returns
-- If `return_lhist` is `true`, returns the validation and training loss histories (`lhist` and `lhist_train`), without computing anything else.
-- Otherwise, returns `false` to operate as expected from a callback function.
+# Callback function returns
+- `callbackstate`: the updated instance of the callback state.
 """
 function create_callback(
         model, θ, val_io_data, loss_function, st;


### PR DESCRIPTION
Few modifications to make the pipeline compatible with HPC system (DAS6)
- Avoid redefinition of `ArrayType` that is done in CoupledNODE.jl
- Avoid using `Plots` now we use `CairoMakie` for the callback and live plotting of the loss evolution during training. We still have the dependency in `Project.toml` should we remove it? Not obvious because in the `evaluation` scripts we create asome visualizations using `Plots`.
- Adapt the new API of the callback in the `train` scripts.
- Update docstring of the callback.
- Delete the other callbacks that are no longer used.

Also confirmed that training a priori and a posteriori are working on DAS6 if the callback is created with `do_plot = false`