### PR TITLE
Fix 151

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CoupledNODE"
 uuid = "88291d29-22ea-41b1-bc0b-03785bffce48"
-authors = ["Pablo Rodríguez Sánchez <pablo.rodriguez.sanchez@gmail.com> , Luisa Orozco <l.orozco@esciencecenter.nl>, Simone Ciarella <s.ciarella@esciencecenter.nl>, Aron Jansen <a.p.jansen@esciencecenter.nl>, Victor Azizi <v.azizi@esciencecenter.nl>"]
+authors = ["Simone Ciarella <s.ciarella@esciencecenter.nl>, Pablo Rodríguez Sánchez <pablo.rodriguez.sanchez@gmail.com>, Luisa Orozco <l.orozco@esciencecenter.nl>,  Aron Jansen <a.p.jansen@esciencecenter.nl>, Victor Azizi <v.azizi@esciencecenter.nl>"]
 version = "0.0.3"
 
 [deps]
@@ -46,7 +46,7 @@ NeuralClosure = {rev = "main", url = "https://github.com/DEEPDIP-project/NeuralC
 
 [extensions]
 CoupledNODECUDA_ext = ["cuDNN", "CUDSS"]
-NavierStokes = ["IncompressibleNavierStokes", "NeuralClosure"]
+NavierStokes = ["IncompressibleNavierStokes", "NeuralClosure", "Adapt"]
 
 [compat]
 Adapt = "4"

--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,11 @@ authors = ["Pablo Rodríguez Sánchez <pablo.rodriguez.sanchez@gmail.com> , Luis
 version = "0.0.3"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -31,15 +32,14 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [weakdeps]
-Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
-cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 IncompressibleNavierStokes = "5e318141-6589-402b-868d-77d7df8c442e"
 Juno = "e5e0dc1b-0480-54bc-9374-aad01c23163d"
 LuxCUDA = "d0bbae9a-e099-4d5b-a835-1c6931763bda"
 NeuralClosure = "099dac27-d7f2-4047-93d5-0baee36b9c25"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
+cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [sources]
 NeuralClosure = {rev = "main", url = "https://github.com/DEEPDIP-project/NeuralClosure.jl.git"}

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Simone Ciarella <s.ciarella@esciencecenter.nl>, Pablo Rodríguez Sá
 version = "0.0.3"
 
 [deps]
-Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
@@ -32,6 +31,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [weakdeps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
 IncompressibleNavierStokes = "5e318141-6589-402b-868d-77d7df8c442e"
 Juno = "e5e0dc1b-0480-54bc-9374-aad01c23163d"

--- a/ext/NavierStokes/NavierStokes.jl
+++ b/ext/NavierStokes/NavierStokes.jl
@@ -4,7 +4,7 @@ using Lux: Lux, relu
 using Random: shuffle
 using NeuralClosure
 using CUDA: CUDA
-using Adapt
+using Adapt: adapt
 
 include("callback.jl")
 include("utils.jl")

--- a/ext/NavierStokes/NavierStokes.jl
+++ b/ext/NavierStokes/NavierStokes.jl
@@ -4,6 +4,7 @@ using Lux: Lux, relu
 using Random: shuffle
 using NeuralClosure
 using CUDA: CUDA
+using Adapt
 
 include("callback.jl")
 include("utils.jl")

--- a/ext/NavierStokes/callback.jl
+++ b/ext/NavierStokes/callback.jl
@@ -1,6 +1,7 @@
 using CairoMakie: CairoMakie
 using Random: Random
 using Statistics: mean
+using Adapt: adapt
 
 """
     create_callback(model, val_io_data; lhist=[], lhist_train=[], nunroll=10, rng=rng, plot_train=true)
@@ -48,7 +49,7 @@ function create_callback(
         average_window = 25,
         device = identity,
         figfile = nothing)
-    to_cpu(x) = adapt(CPU(),x)
+    to_cpu(x) = adapt(CPU(), x)
     if callbackstate === nothing
         # Initialize the callback state
         # To store data coming from CUDA device, we have to serialize them to CPU
@@ -85,7 +86,7 @@ function create_callback(
             y1, y2 = device(dataloader())
             l_val = loss_function(model, p, st, (y1, y2))[1]
             # check if this set of p produces a lower validation loss
-            l_val < callbackstate.loss_min && 
+            l_val < callbackstate.loss_min &&
                 (callbackstate = (; callbackstate..., θmin = to_cpu(p), loss_min = l_val))
             @info "[$(step)] Validation Loss: $(l_val)"
             no_model_loss = loss_function(model, callbackstate.θmin .* 0, st, (y1, y2))[1]

--- a/ext/NavierStokes/callback.jl
+++ b/ext/NavierStokes/callback.jl
@@ -49,15 +49,10 @@ function create_callback(
         average_window = 25,
         device = identity,
         figfile = nothing)
-    to_cpu(x) = adapt(CPU(), x)
+    to_cpu(x) = collect(adapt(CPU(), x))
     if callbackstate === nothing
         # Initialize the callback state
         # To store data coming from CUDA device, we have to serialize them to CPU
-        #CUDA.allowscalar() do
-        #    callbackstate = (;
-        #        θmin = collect(θ), loss_min = eltype(collect(θ))(Inf), lhist_val = [],
-        #        lhist_train = [], lhist_nomodel = [])
-        #end
         callbackstate = (;
             θmin = to_cpu(θ), loss_min = eltype(to_cpu(θ))(Inf), lhist_val = [],
             lhist_train = [], lhist_nomodel = [])

--- a/ext/NavierStokes/callback.jl
+++ b/ext/NavierStokes/callback.jl
@@ -52,7 +52,7 @@ function create_callback(
         # Initialize the callback state
         # To store data coming from CUDA device, we have to serialize them to CPU
         callbackstate = (;
-            θmin = Array(θ), loss_min = eltype(Array(θ))(Inf), lhist_val = [],
+            θmin = collect(θ), loss_min = eltype(collect(θ))(Inf), lhist_val = [],
             lhist_train = [], lhist_nomodel = [])
     end
     if nunroll === nothing && batch_size === nothing
@@ -80,13 +80,13 @@ function create_callback(
             l_val = loss_function(model, p, st, (y1, y2))[1]
             # check if this set of p produces a lower validation loss
             l_val < callbackstate.loss_min &&
-                (callbackstate = (; callbackstate..., θmin = Array(p), loss_min = l_val))
+                (callbackstate = (; callbackstate..., θmin = collect(p), loss_min = collect(l_val)))
             @info "[$(step)] Validation Loss: $(l_val)"
             no_model_loss = loss_function(model, callbackstate.θmin .* 0, st, (y1, y2))[1]
             @info "[$(step)] Validation Loss (no model): $(no_model_loss)"
 
-            push!(callbackstate.lhist_val, l_val)
-            push!(callbackstate.lhist_nomodel, no_model_loss)
+            push!(collect(callbackstate.lhist_val), l_val)
+            push!(collect(callbackstate.lhist_nomodel), no_model_loss)
 
             if do_plot
                 fig = CairoMakie.Figure()

--- a/ext/NavierStokes/callback.jl
+++ b/ext/NavierStokes/callback.jl
@@ -49,7 +49,6 @@ function create_callback(
         average_window = 25,
         device = identity,
         figfile = nothing)
-    to_cpu(x) = collect(adapt(CPU(), x))
     if callbackstate === nothing
         # Initialize the callback state
         # To store data coming from CUDA device, we have to serialize them to CPU
@@ -82,13 +81,13 @@ function create_callback(
             l_val = loss_function(model, p, st, (y1, y2))[1]
             # check if this set of p produces a lower validation loss
             l_val < callbackstate.loss_min &&
-                (callbackstate = (; callbackstate..., θmin = to_cpu(p), loss_min = l_val))
+                (callbackstate = (; callbackstate..., θmin = p, loss_min = l_val))
             @info "[$(step)] Validation Loss: $(l_val)"
-            no_model_loss = loss_function(model, device(callbackstate.θmin .* 0), st, (y1, y2))[1]
+            no_model_loss = loss_function(model, callbackstate.θmin .* 0, st, (y1, y2))[1]
             @info "[$(step)] Validation Loss (no model): $(no_model_loss)"
 
-            push!(to_cpu(callbackstate.lhist_val), l_val)
-            push!(to_cpu(callbackstate.lhist_nomodel), no_model_loss)
+            push!(callbackstate.lhist_val, l_val)
+            push!(callbackstate.lhist_nomodel, no_model_loss)
 
             if do_plot
                 fig = CairoMakie.Figure()

--- a/ext/NavierStokes/callback.jl
+++ b/ext/NavierStokes/callback.jl
@@ -89,7 +89,7 @@ function create_callback(
             l_val < callbackstate.loss_min &&
                 (callbackstate = (; callbackstate..., θmin = to_cpu(p), loss_min = l_val))
             @info "[$(step)] Validation Loss: $(l_val)"
-            no_model_loss = loss_function(model, callbackstate.θmin .* 0, st, (y1, y2))[1]
+            no_model_loss = loss_function(model, device(callbackstate.θmin .* 0), st, (y1, y2))[1]
             @info "[$(step)] Validation Loss (no model): $(no_model_loss)"
 
             push!(to_cpu(callbackstate.lhist_val), l_val)

--- a/ext/NavierStokes/callback.jl
+++ b/ext/NavierStokes/callback.jl
@@ -53,7 +53,7 @@ function create_callback(
         # Initialize the callback state
         # To store data coming from CUDA device, we have to serialize them to CPU
         callbackstate = (;
-            θmin = to_cpu(θ), loss_min = eltype(to_cpu(θ))(Inf), lhist_val = [],
+            θmin = θ, loss_min = eltype(θ)(Inf), lhist_val = [],
             lhist_train = [], lhist_nomodel = [])
     end
     if nunroll === nothing && batch_size === nothing

--- a/ext/NavierStokes/callback.jl
+++ b/ext/NavierStokes/callback.jl
@@ -2,6 +2,7 @@ using CairoMakie: CairoMakie
 using Random: Random
 using Statistics: mean
 using Adapt: adapt
+using Lux: cpu_device
 
 """
     create_callback(model, val_io_data; lhist=[], lhist_train=[], nunroll=10, rng=rng, plot_train=true)
@@ -74,7 +75,7 @@ function create_callback(
         step = length(callbackstate.lhist_train)
 
         plot_train && @info "[$(step)] Training Loss: $(l_train)"
-        push!(callbackstate.lhist_train, l_train)
+        push!(callbackstate.lhist_train, l_train |> cpu_device())
 
         if step % plot_every == 0
             y1, y2 = device(dataloader())
@@ -86,8 +87,8 @@ function create_callback(
             no_model_loss = loss_function(model, callbackstate.θmin .* 0, st, (y1, y2))[1]
             @info "[$(step)] Validation Loss (no model): $(no_model_loss)"
 
-            push!(callbackstate.lhist_val, l_val)
-            push!(callbackstate.lhist_nomodel, no_model_loss)
+            push!(callbackstate.lhist_val, l_val |> cpu_device())
+            push!(callbackstate.lhist_nomodel, no_model_loss |> cpu_device())
 
             if do_plot
                 fig = CairoMakie.Figure()

--- a/src/checkpoints.jl
+++ b/src/checkpoints.jl
@@ -21,9 +21,10 @@ callbackstate, trainstate, epochs_trained = load_checkpoint("checkpoint.jld2")
 ```
 """
 function load_checkpoint(checkfile)
-    checkpoint = load_object(checkfile)
-    callbackstate = checkpoint.callbackstate
-    trainstate = checkpoint.trainstate
+    #checkpoint = load_object(checkfile)
+    #callbackstate = checkpoint.callbackstate
+    #trainstate = checkpoint.trainstate
+    (; callbackstate, trainstate) = namedtupleload(checkfile)
     epochs_trained = length(callbackstate.lhist_train)
     @info "Loading checkpoint from $checkfile.\nPrevious training reached epoch $(epochs_trained)."
     return callbackstate, trainstate, epochs_trained

--- a/src/checkpoints.jl
+++ b/src/checkpoints.jl
@@ -3,6 +3,24 @@ using CUDA: CUDA
 using Lux: Lux
 
 """
+    namedtupleload(file)
+
+Load a JLD2 file and convert it to a named tuple.
+
+# Arguments
+- `file::String`: The path to the JLD2 file.
+
+# Returns
+- `NamedTuple`: The contents of the file as a named tuple.
+"""
+function namedtupleload(file)
+    dict = load(file)
+    k, v = keys(dict), values(dict)
+    pairs = @. Symbol(k) => v
+    (; pairs...)
+end
+
+"""
     load_checkpoint(checkfile)
 
 Load a training checkpoint from the specified file.
@@ -21,11 +39,25 @@ callbackstate, trainstate, epochs_trained = load_checkpoint("checkpoint.jld2")
 ```
 """
 function load_checkpoint(checkfile)
-    #checkpoint = load_object(checkfile)
-    #callbackstate = checkpoint.callbackstate
-    #trainstate = checkpoint.trainstate
     (; callbackstate, trainstate) = namedtupleload(checkfile)
     epochs_trained = length(callbackstate.lhist_train)
     @info "Loading checkpoint from $checkfile.\nPrevious training reached epoch $(epochs_trained)."
     return callbackstate, trainstate, epochs_trained
+end
+
+"""
+    save_checkpoint(checkfile, callbackstate, trainstate)
+
+Save the current training state to a checkpoint file.
+
+# Arguments
+- `checkfile::String`: The path to the checkpoint file.
+- `callbackstate`: The current state of the callback.
+- `trainstate`: The current state of the training process.
+"""
+function save_checkpoint(checkfile, callbackstate, trainstate)
+    @info "Saving checkpoint to $checkfile."
+    c = callbackstate |> cpu_device()
+    t = trainstate |> cpu_device()
+    jldsave(checkfile; callbackstate = c, trainstate = t)
 end

--- a/src/checkpoints.jl
+++ b/src/checkpoints.jl
@@ -25,9 +25,6 @@ function load_checkpoint(checkfile)
     callbackstate = checkpoint.callbackstate
     trainstate = checkpoint.trainstate
     epochs_trained = length(callbackstate.lhist_train)
-    #dev = CUDA.functional() ? Lux.gpu_device() : Lux.cpu_device()
-    #@info "Loading checkpoint from $checkfile and putting it on $dev.\nPrevious training reached epoch $(epochs_trained)."
-    #return callbackstate |> dev, trainstate |> dev, epochs_trained
     @info "Loading checkpoint from $checkfile.\nPrevious training reached epoch $(epochs_trained)."
     return callbackstate, trainstate, epochs_trained
 end

--- a/src/train.jl
+++ b/src/train.jl
@@ -17,7 +17,7 @@ function train(model, ps, st, train_dataloader, loss_function;
     # Retrieve the callback from kwargs, default to `nothing` if not provided
     callback = get(kwargs, :callback, nothing)
     # Retrieve the training state from kwargs, otherwise create a new one
-    tstate = get(kwargs, :tstate, nothing)
+    #tstate = get(kwargs, :tstate, nothing)
     if tstate === nothing
         tstate = Lux.Training.TrainState(model, ps, st, alg)
     end

--- a/src/train.jl
+++ b/src/train.jl
@@ -21,6 +21,7 @@ function train(model, ps, st, train_dataloader, loss_function;
     if tstate === nothing
         tstate = Lux.Training.TrainState(model, ps, st, alg)
     end
+    @warn "Training state type: $(typeof(tstate))"
     loss::Float32 = 0 #NOP TODO: check compatibiity with precision of data
     @info "Lux Training started"
     for epoch in 1:nepochs

--- a/src/train.jl
+++ b/src/train.jl
@@ -17,7 +17,7 @@ function train(model, ps, st, train_dataloader, loss_function;
     # Retrieve the callback from kwargs, default to `nothing` if not provided
     callback = get(kwargs, :callback, nothing)
     # Retrieve the training state from kwargs, otherwise create a new one
-    #tstate = get(kwargs, :tstate, nothing)
+    tstate = get(kwargs, :tstate, nothing)
     if tstate === nothing
         tstate = Lux.Training.TrainState(model, ps, st, alg)
     end

--- a/test/test_checkpoints.jl
+++ b/test/test_checkpoints.jl
@@ -1,0 +1,28 @@
+using Test
+using CoupledNODE: save_checkpoint, load_checkpoint
+using JLD2
+using Random
+using Adapt
+
+@testset "Checkpoint Tests" begin
+    # Create dummy callbackstate and trainstate
+    callbackstate = (lhist_train = [1, 2, 3], lhist_val = [1, 2, 3])
+    trainstate = (weights = rand(3, 3), biases = rand(3))
+
+    # Define checkpoint file path
+    checkfile = "test_checkpoint.jld2"
+
+    # Save checkpoint
+    save_checkpoint(checkfile, callbackstate, trainstate)
+
+    # Load checkpoint
+    loaded_callbackstate, loaded_trainstate, epochs_trained = load_checkpoint(checkfile)
+
+    # Test loaded values
+    @test loaded_callbackstate == callbackstate
+    @test loaded_trainstate == trainstate
+    @test epochs_trained == length(callbackstate.lhist_train)
+
+    # Clean up
+    rm(checkfile, force=true)
+end

--- a/test/test_checkpoints.jl
+++ b/test/test_checkpoints.jl
@@ -24,5 +24,5 @@ using Adapt
     @test epochs_trained == length(callbackstate.lhist_train)
 
     # Clean up
-    rm(checkfile, force=true)
+    rm(checkfile, force = true)
 end


### PR DESCRIPTION
Closes #151 by implementing a more rigorous policy for device transfer and loading/saving.
Main modifications:
1. only `callback.\thetamin` will be stored on the device
2. use `|> dev` instead of `adapt` when applied to the whole `NamedTuple`
3. save/load checkpoints as dictionary and transform in `Tuple` using `CoupledNode.namedtupleload`