### PR TITLE
Remove adaptive

### DIFF
--- a/src/loss/loss_posteriori.jl
+++ b/src/loss/loss_posteriori.jl
@@ -9,7 +9,7 @@ using Lux: Lux
 using ChainRulesCore: ignore_derivatives
 
 """
-    create_loss_post_lux(rhs; sciml_solver = Tsit5(), kwargs...)
+    create_loss_post_lux(rhs; sciml_solver = RK4(), kwargs...)
 
 Creates a loss function for a-posteriori fitting using the given right-hand side (RHS) function `rhs`.
 The loss function computes the sum of squared differences between the predicted values and the actual data,
@@ -17,7 +17,7 @@ normalized by the sum of squared actual data values.
 
 # Arguments
 - `rhs::Function`: The right-hand side function for the ODE problem.
-- `sciml_solver::AbstractODEAlgorithm`: (Optional) The SciML solver to use for solving the ODE problem. Defaults to `Tsit5()`.
+- `sciml_solver::AbstractODEAlgorithm`: (Optional) The SciML solver to use for solving the ODE problem. Defaults to `RK4()`.
 - `kwargs...`: Additional keyword arguments to pass to the solver.
 
 # Returns
@@ -36,8 +36,8 @@ normalized by the sum of squared actual data values.
 This makes it compatible with the Lux ecosystem.
 """
 function create_loss_post_lux(
-        rhs, griddims, inside; ensemble = false,
-        force_cpu = false, sciml_solver = Tsit5(), kwargs...)
+        rhs, griddims, inside, dt; ensemble = false,
+        force_cpu = false, sciml_solver = RK4(), kwargs...)
     function ArrayType()
         if force_cpu
             return Array
@@ -62,7 +62,7 @@ function create_loss_post_lux(
         prob = ODEProblem(rhs, x, tspan, ps)
         pred = solve(
             prob, sciml_solver; u0 = x, p = ps,
-            adaptive = true, save_start = false, saveat = saveat_times, kwargs...)
+            adaptive = false, dt = dt, save_start = false, saveat = saveat_times, kwargs...)
         if size(pred)[4] != size(uref)[4]
             @warn "Instability in the loss function. The predicted and target data have different sizes."
             @info "Predicted size: $(size(pred))"
@@ -115,9 +115,10 @@ function create_loss_post_lux(
 
         sols = solve(
             ensemble_prob, sciml_solver, ensemble_type;
+            dt = dt,
             trajectories = nsamp,
             saveat = saveat_times,
-            adaptive = true,
+            adaptive = false,
             save_start = false
         )
 
@@ -176,7 +177,7 @@ function validate_results(model, p, dataloader, nuse = 100)
         #saveat_loss = [i * dt for i in 1:length(y)]
         tspan = [t[1], t[end]]
         prob = ODEProblem(model, x, tspan, p)
-        pred = Array(solve(prob, Tsit5(); u0 = x, p = p, dt = dt, adaptive = false))
+        pred = Array(solve(prob, RK4(); u0 = x, p = p, dt = dt, adaptive = false))
         # remember that the first element of pred is the initial condition (SciML)
         loss += sum(
             abs2, y[griddims..., :, 1:(size(pred, 4) - 1)] - pred[griddims..., :, 2:end]) /

--- a/test/test_aposteriori.jl
+++ b/test/test_aposteriori.jl
@@ -15,6 +15,7 @@ T = Float32
 rng = Random.Xoshiro(123)
 ig = 1 # index of the LES grid to use.
 nunroll = 5
+dt = T(1e-4)
 
 # Load the data
 data = load("test_data/data_train.jld2", "data_train")
@@ -68,7 +69,8 @@ inside = ((:) for _ in 1:D)
     loss_posteriori_lux = create_loss_post_lux(
         dudt_nn2,
         griddims,
-        inside;
+        inside,
+        dt;
     )
     loss_value = loss_posteriori_lux(closure, θ, st, train_data_posteriori)
     @test isfinite(loss_value[1]) # Check that the loss value is finite
@@ -158,7 +160,8 @@ end
     loss_posteriori_lux = create_loss_post_lux(
         dudt_nn2,
         griddims,
-        inside;
+        inside,
+        dt;
     )
     loss_value = loss_posteriori_lux(closure, θ, st, train_data_posteriori)
     @test isfinite(loss_value[1]) # Check that the loss value is finite

--- a/test/test_inplace_dyn.jl
+++ b/test/test_inplace_dyn.jl
@@ -54,10 +54,10 @@ d = D = params.D
     prob_out = ODEProblem(Fout, ustart, tspan, nothing)
 
     # First a burn-in simulation
-    burn_in = solve(prob_in, Tsit5(); u0 = ustart, p = nothing,
-        adaptive = true, saveat = 0.5, dt = T(1e-5), tspan = tspan)
-    burn_out = solve(prob_out, Tsit5(); u0 = ustart, p = nothing,
-        adaptive = true, saveat = 0.5, dt = T(1e-5), tspan = tspan)
+    burn_in = solve(prob_in, RK4(); u0 = ustart, p = nothing,
+        adaptive = false, saveat = 0.5, dt = T(1e-5), tspan = tspan)
+    burn_out = solve(prob_out, RK4(); u0 = ustart, p = nothing,
+        adaptive = false, saveat = 0.5, dt = T(1e-5), tspan = tspan)
     @test burn_in.u ≈ burn_out.u
     ustart = burn_in.u[end]
 
@@ -65,25 +65,25 @@ d = D = params.D
     _, _,
     _,
     _ = @timed solve(
-        prob_out, Tsit5(); u0 = ustart, p = nothing,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_out, RK4(); u0 = ustart, p = nothing,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
     _, _,
     _,
     _ = @timed solve(
-        prob_in, Tsit5(); u0 = ustart, p = nothing,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_in, RK4(); u0 = ustart, p = nothing,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
 
     # Now the real simulations
     solution_in, t_in,
     mem_in,
     _ = @timed solve(
-        prob_in, Tsit5(); u0 = ustart, p = nothing,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_in, RK4(); u0 = ustart, p = nothing,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
     solution_out, t_out,
     mem_out,
     _ = @timed solve(
-        prob_out, Tsit5(); u0 = ustart, p = nothing,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_out, RK4(); u0 = ustart, p = nothing,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
 
     @test solution_in.u ≈ solution_out.u
     @test solution_in.t ≈ solution_out.t
@@ -125,10 +125,10 @@ end
     prob_out = ODEProblem(Fout, ustart, tspan, nothing)
 
     # First a burn-in simulation
-    burn_in = solve(prob_in, Tsit5(); u0 = ustart, p = nothing,
-        adaptive = true, saveat = 0.5, dt = T(1e-5), tspan = tspan)
-    burn_out = solve(prob_out, Tsit5(); u0 = ustart, p = nothing,
-        adaptive = true, saveat = 0.5, dt = T(1e-5), tspan = tspan)
+    burn_in = solve(prob_in, RK4(); u0 = ustart, p = nothing,
+        adaptive = false, saveat = 0.5, dt = T(1e-5), tspan = tspan)
+    burn_out = solve(prob_out, RK4(); u0 = ustart, p = nothing,
+        adaptive = false, saveat = 0.5, dt = T(1e-5), tspan = tspan)
     @test burn_in.u ≈ burn_out.u
     @test is_on_gpu(burn_in.u[end])
     @test is_on_gpu(burn_out.u[end])
@@ -138,25 +138,25 @@ end
     _, _,
     _,
     _ = @timed solve(
-        prob_out, Tsit5(); u0 = ustart, p = nothing,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_out, RK4(); u0 = ustart, p = nothing,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
     _, _,
     _,
     _ = @timed solve(
-        prob_in, Tsit5(); u0 = ustart, p = nothing,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_in, RK4(); u0 = ustart, p = nothing,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
 
     # Now the real simulations
     solution_in, t_in,
     mem_in,
     _ = @timed solve(
-        prob_in, Tsit5(); u0 = ustart, p = nothing,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_in, RK4(); u0 = ustart, p = nothing,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
     solution_out, t_out,
     mem_out,
     _ = @timed solve(
-        prob_out, Tsit5(); u0 = ustart, p = nothing,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_out, RK4(); u0 = ustart, p = nothing,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
 
     @test solution_in.u ≈ solution_out.u
     @test solution_in.t ≈ solution_out.t
@@ -201,10 +201,10 @@ end
     prob_out = ODEProblem(Fout, ustart, tspan, θ)
 
     # First a burn-in simulation
-    burn_in = solve(prob_in, Tsit5(); u0 = ustart, p = θ,
-        adaptive = true, saveat = T(0.5), dt = T(1e-5), tspan = tspan)
-    burn_out = solve(prob_out, Tsit5(); u0 = ustart, p = θ,
-        adaptive = true, saveat = T(0.5), dt = T(1e-5), tspan = tspan)
+    burn_in = solve(prob_in, RK4(); u0 = ustart, p = θ,
+        adaptive = false, saveat = T(0.5), dt = T(1e-5), tspan = tspan)
+    burn_out = solve(prob_out, RK4(); u0 = ustart, p = θ,
+        adaptive = false, saveat = T(0.5), dt = T(1e-5), tspan = tspan)
     @test burn_in.u ≈ burn_out.u
     ustart = burn_in.u[end]
 
@@ -212,25 +212,25 @@ end
     _, _,
     _,
     _ = @timed solve(
-        prob_out, Tsit5(); u0 = ustart, p = θ,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_out, RK4(); u0 = ustart, p = θ,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
     _, _,
     _,
     _ = @timed solve(
-        prob_in, Tsit5(); u0 = ustart, p = θ,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_in, RK4(); u0 = ustart, p = θ,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
 
     # Now the real simulations
     solution_in, t_in,
     mem_in,
     _ = @timed solve(
-        prob_in, Tsit5(); u0 = ustart, p = θ,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_in, RK4(); u0 = ustart, p = θ,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
     solution_out, t_out,
     mem_out,
     _ = @timed solve(
-        prob_out, Tsit5(); u0 = ustart, p = θ,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_out, RK4(); u0 = ustart, p = θ,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
 
     @test solution_in.u ≈ solution_out.u
     @test solution_in.t ≈ solution_out.t
@@ -286,10 +286,10 @@ end
     prob_out = ODEProblem(Fout, ustart, tspan, θ)
 
     # First a burn-in simulation
-    burn_in = solve(prob_in, Tsit5(); u0 = ustart, p = θ,
-        adaptive = true, saveat = 0.5, dt = T(1e-5), tspan = tspan)
-    burn_out = solve(prob_out, Tsit5(); u0 = ustart, p = θ,
-        adaptive = true, saveat = 0.5, dt = T(1e-5), tspan = tspan)
+    burn_in = solve(prob_in, RK4(); u0 = ustart, p = θ,
+        adaptive = false, saveat = 0.5, dt = T(1e-5), tspan = tspan)
+    burn_out = solve(prob_out, RK4(); u0 = ustart, p = θ,
+        adaptive = false, saveat = 0.5, dt = T(1e-5), tspan = tspan)
     @test burn_in.u ≈ burn_out.u
     @test is_on_gpu(burn_in.u[end])
     @test is_on_gpu(burn_out.u[end])
@@ -299,25 +299,25 @@ end
     _, _,
     _,
     _ = @timed solve(
-        prob_out, Tsit5(); u0 = ustart, p = θ,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_out, RK4(); u0 = ustart, p = θ,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
     _, _,
     _,
     _ = @timed solve(
-        prob_in, Tsit5(); u0 = ustart, p = θ,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_in, RK4(); u0 = ustart, p = θ,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
 
     # Now the real simulations
     solution_in, t_in,
     mem_in,
     _ = @timed solve(
-        prob_in, Tsit5(); u0 = ustart, p = θ,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_in, RK4(); u0 = ustart, p = θ,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
     solution_out, t_out,
     mem_out,
     _ = @timed solve(
-        prob_out, Tsit5(); u0 = ustart, p = θ,
-        adaptive = true, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
+        prob_out, RK4(); u0 = ustart, p = θ,
+        adaptive = false, saveat = T(1e-4), dt = T(1e-5), tspan = tspan)
 
     @test solution_in.u ≈ solution_out.u
     @test solution_in.t ≈ solution_out.t

--- a/test/test_lossensemble.jl.disabled
+++ b/test/test_lossensemble.jl.disabled
@@ -18,6 +18,7 @@ rng = Random.Xoshiro(123)
 ig = 1 # index of the LES grid to use.
 nunroll = 3
 nsamps = [1, 2, 3]
+dt = T(1e-4)
 
 # Load the data
 data = load("test_data/data_train.jld2", "data_train")
@@ -29,7 +30,7 @@ griddims = ((:) for _ in 1:D)
 inside = ((:) for _ in 1:D)
 
 function create_sequential_loss_post(
-        rhs, griddims, inside; sciml_solver = Tsit5(), kwargs...)
+        rhs, griddims, inside; sciml_solver = RK4(), kwargs...)
     @warn "This function is used only for testing purposes."
 
     # [!] This commented out function could be used as an alternative to the ensemble loss function.
@@ -55,7 +56,7 @@ function create_sequential_loss_post(
     #        prob = ODEProblem(rhs, x0, tspan, ps)
     #        pred = solve(
     #            prob, sciml_solver; u0 = x0, p = ps,
-    #            adaptive = true, save_start = false, saveat = saveat_times, kwargs...
+    #            adaptive = false, save_start = false, saveat = saveat_times, kwargs...
     #        )
     #        pred[inside..., :, :]
     #    end
@@ -96,7 +97,7 @@ function create_sequential_loss_post(
             prob = ODEProblem(rhs, x, tspan, ps)
             pred = solve(
                 prob, sciml_solver; u0 = x, p = ps,
-                adaptive = true, save_start = false, saveat = Array(t), kwargs...)
+                adaptive = false, save_start = false, saveat = Array(t), kwargs...)
             if size(pred)[4] != size(uref)[4]
                 @warn "Instability in the loss function. The predicted and target data have different sizes."
                 @info "Predicted size: $(size(pred))"
@@ -164,6 +165,7 @@ for NSAMP in nsamps
             dudt_nn2,
             griddims,
             inside,
+            dt
             ;
             ensemble = true,
             force_cpu = true
@@ -258,6 +260,7 @@ for NSAMP in nsamps
             dudt_nn2,
             griddims,
             inside,
+            dt
             ;
             ensemble = true
         )

--- a/test/test_losssens.jl
+++ b/test/test_losssens.jl
@@ -16,6 +16,7 @@ T = Float32
 rng = Random.Xoshiro(123)
 ig = 1 # index of the LES grid to use.
 nunroll = 5
+dt = T(1e-4)
 
 # Load the data
 data = load("test_data/data_train.jld2", "data_train")
@@ -68,7 +69,8 @@ for SENSEALG_i in sensealgs
         loss_posteriori_lux = create_loss_post_lux(
             dudt_nn2,
             griddims,
-            inside;
+            inside,
+            dt;
             sensealg = SENSEALG_i
         )
         loss_value = loss_posteriori_lux(closure, θ, st, train_data_posteriori)
@@ -164,7 +166,8 @@ for SENSEALG_i in sensealgs
         loss_posteriori_lux = create_loss_post_lux(
             dudt_nn2,
             griddims,
-            inside;
+            inside,
+            dt;
             sensealg = SENSEALG_i
         )
         loss_value = loss_posteriori_lux(closure, θ, st, train_data_posteriori)

--- a/test/test_sensealg.jl
+++ b/test/test_sensealg.jl
@@ -16,6 +16,7 @@ using Optimization: Optimization
 using OptimizationOptimisers: OptimizationOptimisers
 using SciMLSensitivity
 
+dt = Float32(1e-4)
 # Define the test set
 NON_supported = [ForwardDiffSensitivity(), ZygoteAdjoint(), TrackerAdjoint(),
     ReverseDiffAdjoint(), QuadratureAdjoint()]
@@ -95,7 +96,8 @@ for SENSEALG_i in sensealgs
         loss_posteriori_lux = create_loss_post_lux(
             dudt_nn2,
             griddims,
-            inside;
+            inside,
+            dt;
             sensealg = SENSEALG_i
         )
         loss_value = loss_posteriori_lux(closure, θ, st, train_data_posteriori)


### PR DESCRIPTION
This PR decides to set `adaptive=false` and set `RK4()` as default solver because the adaptive nature of `Tsit5()` actually made it worse in a context of closure learning, because the adaptive window was not consistent between data generation and training.